### PR TITLE
fix no space left bug in lorax creating runtime  image

### DIFF
--- a/src/rocks-boot-7/Makefile
+++ b/src/rocks-boot-7/Makefile
@@ -81,7 +81,7 @@ build:
 	## Create a local repo of THIS roll's RPMS
 	$(MAKE) -C $(REDHAT.ROOT) createlocalrepo
 	## Use Lorax to Build images
-	lorax $(ISFINAL) -p Rocks -v $(ROCKS_VERSION) -r $(RELEASE) -s `pwd`/rocks-dist/$(ARCH) -s $(REDHAT.ROOT)/localrepo -c `pwd`/$(LORAXCONF) --noupgrade `pwd`/$(LORAXBUILD) 
+	lorax $(ISFINAL) -p Rocks -v $(ROCKS_VERSION) -r $(RELEASE) -s `pwd`/rocks-dist/$(ARCH) -s $(REDHAT.ROOT)/localrepo -c `pwd`/$(LORAXCONF) --noupgrade --rootfs-size=3 `pwd`/$(LORAXBUILD) 
 
 
 showvars:


### PR DESCRIPTION
The default rootfs image size is too small for us.

refer to
https://github.com/weldr/lorax/blob/lorax-19.7.26-1/src/sbin/lorax#L192